### PR TITLE
feat: export date-fns properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.1 - 2025-6-28
+
+Charging the way that `date-fns` is exposed to allow users to import the proxied functions
+
+
 # 1.1.0 - 2025-6-21
 
 This pull request updates the `packages/lib` module to enhance its functionality and improve code organization. Key changes include restructuring the `exports` in `package.json`, adding new dependencies, and introducing a new utility for converting time strings to milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1359,7 +1359,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2985,7 +2984,7 @@
     },
     "packages/lib": {
       "name": "@omariosouto/common-core",
-      "version": "1.0.5",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "^2.1.0",
@@ -2998,7 +2997,6 @@
         "@omariosouto/tsconfig": "1.13.11",
         "@types/lodash-es": "4.17.12",
         "@types/node": "^22.14.1",
-        "date-fns": "4.1.0",
         "jsdom": "^26.1.0",
         "tsup": "^8.4.0",
         "typescript": "^5.0.0",

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.1 - 2025-6-28
+
+Charging the way that `date-fns` is exposed to allow users to import the proxied functions
+
+
 # 1.1.0 - 2025-6-21
 
 This pull request updates the `packages/lib` module to enhance its functionality and improve code organization. Key changes include restructuring the `exports` in `package.json`, adding new dependencies, and introducing a new utility for converting time strings to milliseconds.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,9 +12,9 @@
   "license": "MIT",
   "description": "",
   "exports": {
-    "./date": "./dist/date.js",
-    ".": "./dist/index.js",
-    "./test": "./dist/test.js"
+    ".": "./src/index.ts",
+    "./date": "./src/date.ts",
+    "./test": "./src/testtjs"
   },
   "files": [
     "dist"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -25,12 +25,12 @@
   },
   "dependencies": {
     "@types/ms": "^2.1.0",
-    "date-fns": "^4.1.0",
     "decimal.js": "^10.5.0",
     "lodash-es": "^4.17.21",
     "ms": "2.1.3"
   },
   "devDependencies": {
+    "date-fns": "^4.1.0",
     "@omariosouto/tsconfig": "1.13.11",
     "@types/lodash-es": "4.17.12",
     "@types/node": "^22.14.1",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,9 +12,9 @@
   "license": "MIT",
   "description": "",
   "exports": {
-    ".": "./src/index.ts",
-    "./date": "./src/date.ts",
-    "./test": "./src/testtjs"
+    "./date": "./dist/date.js",
+    ".": "./dist/index.js",
+    "./test": "./dist/test.js"
   },
   "files": [
     "dist"
@@ -34,7 +34,6 @@
     "@omariosouto/tsconfig": "1.13.11",
     "@types/lodash-es": "4.17.12",
     "@types/node": "^22.14.1",
-    "date-fns": "4.1.0",
     "jsdom": "^26.1.0",
     "tsup": "^8.4.0",
     "typescript": "^5.0.0",

--- a/packages/lib/src/date/index.test.ts
+++ b/packages/lib/src/date/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { addDays } from "./index";
+
+describe("addDays()", () => {
+  it("should add days to a date", () => {
+    const date = new Date("2021-01-01");
+    const result = addDays(date, 1);
+    expect(result).toEqual(new Date("2021-01-02"));
+  });
+});

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,3 +1,2 @@
 export * from "./sleep";
 export * from "./BigDecimal";
-export * from "lodash-es";

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -43,5 +43,5 @@ export default defineConfig({
   outDir: 'dist',
   clean: true,
   // Bundle dependencies instead of treating them as external
-  noExternal: ['date-fns', 'lodash-es']
+  noExternal: ['date-fns']
 });

--- a/packages/lib/tsup.config.ts
+++ b/packages/lib/tsup.config.ts
@@ -41,5 +41,7 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   dts: true,
   outDir: 'dist',
-  clean: true
+  clean: true,
+  // Bundle dependencies instead of treating them as external
+  noExternal: ['date-fns', 'lodash-es']
 });


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

Charging the way that `date-fns` is exposed to allow users to import the proxied functions
