### PR TITLE
feat: fixing lodash export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.2 - 2025-6-28
+
+This pull request includes a small change to the `packages/lib/src/index.ts` file. The change adds an export for the `lodash-es` library, making its utilities available for use across the project.
+
+
 # 1.1.1 - 2025-6-28
 
 Charging the way that `date-fns` is exposed to allow users to import the proxied functions

--- a/packages/lib/CHANGELOG.md
+++ b/packages/lib/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.2 - 2025-6-28
+
+This pull request includes a small change to the `packages/lib/src/index.ts` file. The change adds an export for the `lodash-es` library, making its utilities available for use across the project.
+
+
 # 1.1.1 - 2025-6-28
 
 Charging the way that `date-fns` is exposed to allow users to import the proxied functions

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omariosouto/common-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./sleep";
 export * from "./BigDecimal";
+export * from "lodash-es";


### PR DESCRIPTION
## Lib Management

| Commands to manage version bumps |
| --- |
| bumper/release |
| bumper/beta    |
| bumper/skip    |

## Changelog

This pull request includes a small change to the `packages/lib/src/index.ts` file. The change adds an export for the `lodash-es` library, making its utilities available for use across the project.
